### PR TITLE
Start MetaMask Wallet integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# TheOrugginTrail ZorkMUD<>ZorkDojo
-A MUD (and eventually also Dojo) based Zork-like experiment in fully onchain text adventures, onchain games framework interoperability, and the engines that drive them.
+# TheOrugginTrail
+A MUD (and eventually also Dojo, World Engine, and who-knows) based Zork-like experiment in fully onchain text adventures, onchain games framework interoperability, and the engines that drive them.
 
 >        \/|
 >       /"" ;,_               _________
@@ -13,7 +13,7 @@ A MUD (and eventually also Dojo) based Zork-like experiment in fully onchain tex
 
 What lies ahead, is anyone's guess...
 
-This project is a test-case for taking a zork-like text adventure engine and porting it to onchain gaming engines and frameworks like MUD and Dojo, and from there seeing if interesting interoperability between the engines can be connected and experimented with.
+This project is a test-case for taking a zork-like text adventure engine and porting it to onchain gaming engines and frameworks like MUD, Dojo, and World Engine... and from there seeing if interesting interoperability between the engines can be connected and experimented with.
 
 We are porting / reinterpreting the MIT Zork design and architecture for text adventure engines onchain, this model eventually became the base for Infocom games and such favoured classics as Commodore64's The Hitchikers Guide To The Galaxy, one of the most ambitious and complex text adventures ever made. To get a primer and learn more about the engine and explore it's history and and the engineering principles under the hood please read these resources:
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,7 @@
 # TheOrugginTrail
 A MUD (and eventually also Dojo, World Engine, and who-knows) based Zork-like experiment in fully onchain text adventures, onchain games framework interoperability, and the engines that drive them.
 
->        \/|
->       /"" ;,_               _________
->      oo _. //..___.._      |,--------
->      `-' `//=========================
->          `'\          |    ||
->            |//-----'\ (    || ,d88b,
->            //       |||    `|_888888_
->            \\_      |||       888888
->           '-\/     '/_(       `Y88P' fL
+![ad_2_final](https://github.com/ArchetypalTech/TheOrugginTrail/assets/983878/b90bcc55-2ba1-4564-94e1-d08184c1e49c)
 
 What lies ahead, is anyone's guess...
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # TheOrugginTrail
 A MUD (and eventually also Dojo, World Engine, and who-knows) based Zork-like experiment in fully onchain text adventures, onchain games framework interoperability, and the engines that drive them.
+What lies ahead, is anyone's guess...
 
 ![ad_2_final](https://github.com/ArchetypalTech/TheOrugginTrail/assets/983878/b90bcc55-2ba1-4564-94e1-d08184c1e49c)
 
-What lies ahead, is anyone's guess...
+
 
 This project is a test-case for taking a zork-like text adventure engine and porting it to onchain gaming engines and frameworks like MUD, Dojo, and World Engine... and from there seeing if interesting interoperability between the engines can be connected and experimented with.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ What lies ahead, is anyone's guess...
 
 
 
-This project is a test-case for taking a zork-like text adventure engine and reimagining it in onchain gaming engines and frameworks like MUD, Dojo, and World Engine... and from there seeing if interesting interoperability between the engines can be connected and experimented with. This iwl also give an opportunity to see if any of the differences and affordances between frameworks and onchain game engines generate varied or new gameplay paradigms and directions.
+This project is a test-case for taking a zork-like text adventure engine and reimagining it in onchain gaming engines and frameworks like MUD, Dojo, and World Engine... and from there seeing if interesting interoperability between the engines can be connected and experimented with. This will also give an opportunity to see if any of the differences and affordances between frameworks and onchain game engines generate varied or new gameplay paradigms and directions.
 
 We are porting / reinterpreting the MIT Zork design and architecture for text adventure engines onchain, this model eventually became the base for Infocom games and such favoured classics as Commodore64's The Hitchikers Guide To The Galaxy, one of the most ambitious and complex text adventures ever made. To get a primer and learn more about the engine and explore it's history and and the engineering principles under the hood please read these resources:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ What lies ahead, is anyone's guess...
 
 
 
-This project is a test-case for taking a zork-like text adventure engine and porting it to onchain gaming engines and frameworks like MUD, Dojo, and World Engine... and from there seeing if interesting interoperability between the engines can be connected and experimented with.
+This project is a test-case for taking a zork-like text adventure engine and reimagining it in onchain gaming engines and frameworks like MUD, Dojo, and World Engine... and from there seeing if interesting interoperability between the engines can be connected and experimented with. This iwl also give an opportunity to see if any of the differences and affordances between frameworks and onchain game engines generate varied or new gameplay paradigms and directions.
 
 We are porting / reinterpreting the MIT Zork design and architecture for text adventure engines onchain, this model eventually became the base for Infocom games and such favoured classics as Commodore64's The Hitchikers Guide To The Galaxy, one of the most ambitious and complex text adventures ever made. To get a primer and learn more about the engine and explore it's history and and the engineering principles under the hood please read these resources:
 
@@ -16,7 +16,7 @@ https://github.com/MITDDC/zork
 
 https://medium.com/swlh/zork-the-great-inner-workings-b68012952bdc
 
-This will Zork-like MUD engine be piloted by a text adventure called the O'ruggin Trail.
+This Zork-like engine will be piloted by a text adventure called the O'ruggin Trail.
 
 WARNING: attempting a crossing to the frontiers of crypto country ultimately always results in horrible death... physical, moral, ego, or otherwise.
 


### PR DESCRIPTION
* Adds in a key to a funded fluent wallet that is used to generate the address that the client uses instead of a burner wallet. This is purely for testing.
* Adds a metamask connection button that renders in a modal the address is hardcoded right now.