### PR TITLE
Terminal/wallet repositioning

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -8,9 +8,11 @@
   </head>
   <body>
       <div id="gameview">
-          <l-wallet></l-wallet>
-          <l-terminal></l-terminal>
-          <div id="viewport"></div>
+		<div id="ui_content">
+		  <l-wallet></l-wallet>
+		  <l-terminal id="terminal"></l-terminal>
+		</div>
+        <div id="viewport"></div>
       </div>
   </body>
 </html>

--- a/packages/client/src/styles/defaultStyle.css
+++ b/packages/client/src/styles/defaultStyle.css
@@ -1,14 +1,32 @@
 body {
-    margin: 4;
-    padding: 4;
-    background-color: black;
-    color: white;
+  background-color: black;
+  color: white;
+  margin: 0;
+  padding: 0;
 }
 #gameview {
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  width: 100%;
+  position: relative;
 }
 ::-webkit-scrollbar {
-    width: 8px; /* Includes the "border" */
+  width: 8px; /* Includes the "border" */
+}
+
+#ui_content {
+  position: absolute;
+  width: 33%;
+  height: 66%;
+  min-width: 350px;
+  left: 50%;
+  bottom: 50%;
+  transform: translateX(-50%) translateY(50%);
+  display: flex;
+  flex-direction: column;
+}
+
+#terminal {
+  height: 100%;
 }

--- a/packages/client/src/styles/termStyle.ts
+++ b/packages/client/src/styles/termStyle.ts
@@ -41,14 +41,16 @@ const cssString: string = `:host {
       }
 
       .terminal {
-          width: 40%;
           color: forestgreen;
           background: black;
           border: 1px solid chartreuse;
           border-radius: 4px;
           font-family: 'Courier', sans-serif;
           font-size: 16px;
-          margin: 4px;
+          margin-top: 4px;
+          margin-bottom: 4px;
+          height: calc(100% - 8px);
+          height: 100%;
       }
 
       .output {

--- a/packages/client/src/styles/wallet/walletStyle.ts
+++ b/packages/client/src/styles/wallet/walletStyle.ts
@@ -17,7 +17,7 @@ input {
     margin-right: 4px;
 }
 .wallet {
-    width: 40%;
+    width: 100%;
     height: 100px;
     overflow-y: auto;
     color: greenyellow;
@@ -26,7 +26,6 @@ input {
     border-radius: 4px;
     font-family: 'Courier', sans-serif;
     font-size: 16px;
-    margin: 4px;
 }
 ::-webkit-scrollbar {
     width: 11px; /* Includes the "border" */


### PR DESCRIPTION
- Moved the terminal to the centre
- Terminal width is now 33% of the screen with a minimum of 350px which still displays the text nicely.
- The height of the terminal + wallet is 66% of the screen.