### PR TITLE
Act 1 Rooms, no sized array when creation

### DIFF
--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -44,7 +44,7 @@ export default mudConfig({
         RoomType: [
             "None", "WoodCabin", "Store",
             "Cavern", "StoneCabin", "Fort", "Room",
-            "Plain"
+            "Plain", "Forge"
         ],
         /** @dev use these to set direction bits on a DirectionObject
          * such as a door
@@ -75,7 +75,7 @@ export default mudConfig({
         ],
         // add these to rooms for stuff to do
         ObjectType: [
-            "None", "Football", "Key", "Knife", "Bottle", "Straw", "Petrol"
+            "None", "Football", "Key", "Knife", "Bottle", "Straw", "Petrol", "Matches"
         ],
         GrammarType: ["None", "DefiniteArticle", "Preposition", "Adverb", "DemPronoun"],
         MaterialType: ["None", "Wood", "Stone", "Iron", "Shit", "IKEA", "Flesh",

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -44,7 +44,7 @@ export default mudConfig({
         RoomType: [
             "None", "WoodCabin", "Store",
             "Cavern", "StoneCabin", "Fort", "Room",
-            "Plain", "Forge"
+            "Plain", "Forge", "Cellar"
         ],
         /** @dev use these to set direction bits on a DirectionObject
          * such as a door
@@ -59,7 +59,7 @@ export default mudConfig({
          */
         DirObjectType: [
             "None", "Door", "Window", "Stairs", "Ladder",
-            "Path", "Trail"
+            "Path", "Trail", "Boulder"
         ],
         /**
          * @dev use these in the parser, they are VERBS
@@ -71,11 +71,11 @@ export default mudConfig({
             "Take", "Kick", "Lock", "Unlock", "Open",
             "Look", "Close", "Break", "Throw", "Drop",
             "Inventory", "Burn", "Light", "Damage", "Hit",
-            "Aquire"
+            "Aquire", "Sniff"
         ],
         // add these to rooms for stuff to do
         ObjectType: [
-            "None", "Football", "Key", "Knife", "Bottle", "Straw", "Petrol", "Matches"
+            "None", "Football", "Key", "Knife", "Bottle", "Straw", "Petrol", "Matches", "Dynamite", "Glue"
         ],
         GrammarType: ["None", "DefiniteArticle", "Preposition", "Adverb", "DemPronoun"],
         MaterialType: ["None", "Wood", "Stone", "Iron", "Shit", "IKEA", "Flesh",

--- a/packages/contracts/src/systems/GameSetupSystem.sol
+++ b/packages/contracts/src/systems/GameSetupSystem.sol
@@ -20,6 +20,7 @@ contract GameSetupSystem is System, Constants {
     uint32 dirObjId = 1;
     uint32 objId = 1;
     uint32 actionId = 1;
+    uint32 KCellar = 4;
     uint32 KForge = 3;
     uint32 KPlain = 2;
     uint32 KBarn = 1;
@@ -214,23 +215,40 @@ contract GameSetupSystem is System, Constants {
                                 "door", barn_plain);
         dObjs[0] = dirObj1;
 
+        // KBARN -> E
         // this is NOT enabled NOR OPEN
-        uint32 open_2_forest = createAction(ActionType.Open, "the window, glass and frame smashed"
+        uint32 open_2_forge = createAction(ActionType.Open, "the window, glass and frame smashed"
                                 " falls open", false, false, false, 0, 0);
 
         uint32 smash_window = createAction(ActionType.Break, "I love the sound of breaking glass\n"
                                 "especially when I'm lonely, the panes and the frame shatter\n"
                                 "satisfyingly spreading broken joy on the floor"
-                                , true, false, false, open_2_forest, 0);
+                                , true, false, false, open_2_forge, 0);
 
         uint32[MAX_OBJ] memory window_actions;
-        window_actions[0] = open_2_forest;
+        window_actions[0] = open_2_forge;
         window_actions[1] = smash_window;
 
         uint32 dirObj2 = createDirObj(DirectionType.East, KForge,
                                 DirObjectType.Window, MaterialType.Wood,
                                 "window", window_actions);
         dObjs[1] = dirObj2;
+
+
+        // KBARN -> DOWN
+        uint32 open_2_cellar = createAction(ActionType.Open, "The hay having burnt fast reveals a set of stairs.", false, false, false, 0, 0);
+        uint32 burn_hay = createAction(ActionType.Burn, "You hear the cracking noise of the hay burning quickly as it is consumed by the dark fires\n"
+                                "sadly, this enjoyable moment is short lived."
+                                , true, false, false, open_2_cellar, 0);
+        
+        uint32[MAX_OBJ] memory hay_actions;
+        hay_actions[0] = open_2_cellar;
+        hay_actions[1] = burn_hay;
+
+        uint32 dirObj3 = createDirObj(DirectionType.Down, KCellar,
+                                DirObjectType.Stairs, MaterialType.Stone,
+                                "stairs filled by a stack of hay", hay_actions);
+        dObjs[2] = dirObj3;
 
         bytes32 tid_barn = keccak256(abi.encodePacked("a barn"));
         TxtDefStore.set(tid_barn, KBarn, TxtDefType.Place,
@@ -242,6 +260,66 @@ contract GameSetupSystem is System, Constants {
         RoomStore.setDescription(KBarn, 'a barn');
         RoomStore.setRoomType(KBarn, RoomType.Room);
         createPlace(KBarn, dObjs, objs, tid_barn);
+    }
+
+      function _setupCellar() private {
+        // KCELLAR -> UP
+        uint32 open_2_barn = createAction(ActionType.Open, "the way is opened\n"
+                                "just don't fall when going up",
+                                true, true, true, 0, 0);
+
+        uint32[MAX_OBJ] memory cellar_barn;
+        uint32[MAX_OBJ] memory dObjs;
+        uint32[MAX_OBJ] memory objs;
+
+        cellar_barn[0] = open_2_barn;
+
+        uint32 dirObj1 = createDirObj(DirectionType.Up, KBarn,
+                              DirObjectType.Stairs, MaterialType.Stone,
+                              "stairs", cellar_barn);
+        dObjs[0] = dirObj1;
+
+        // Dynamite Object
+        uint32 lightDynamite = createAction(ActionType.Light, "Seeing the fuse sparkling makes you remember the fireworks you loved as a child.\n"
+                                "Suddenly, you return back and see that there is almost no time.\n"
+                                "You have to do something or you will be turned to meat puree",
+                                true, false, true, 0, 0);
+
+         uint32 throwDynamite = createAction(ActionType.Throw, "You throw quickly the dynamite\n"
+                                "and start running for the hills as your life depends on it",
+                                true, false, true, 0, 0);
+
+        uint32[MAX_OBJ] memory dynamite_actions;
+        dynamite_actions[0] = lightDynamite;
+        dynamite_actions[1] = throwDynamite;
+
+        uint32 obj1 = createObject(ObjectType.Dynamite, MaterialType.IKEA,
+                                "a high quality (if old) dynamite with a quick fuse.\n"
+                                "It needs to be lit first", "dynamite", dynamite_actions);
+        objs[0] = obj1;
+
+        // Glue Object
+        uint32 sniffGlue = createAction(ActionType.Sniff, "The smell of it is really relaxing,\n"
+                                "but for now thats all",
+                                true, false, true, 0, 0);
+
+        uint32[MAX_OBJ] memory glue_actions;
+        dynamite_actions[0] = sniffGlue; 
+
+        uint32 obj2 = createObject(ObjectType.Glue, MaterialType.Shit,
+                                "some oddly named glue.\n"
+                                "Not knowing if its your imagination it seems to be calling you", "glue", glue_actions);
+        objs[1] = obj2;
+
+        RoomStore.setDescription(KCellar,  'a small cellar');
+        RoomStore.setRoomType(KCellar,  RoomType.Cellar);
+
+        bytes32 tid_plain = keccak256(abi.encodePacked('a small cellar'));
+        TxtDefStore.set(tid_plain, KPlain, TxtDefType.Place, "big enough to hide probably fifty people.\n"
+                                                                "It seems that it was constructed with great care as you can't find any cracks or holes in the walls.\n"
+                                                                "This place might be important.");
+
+        createPlace(KCellar, dObjs, objs, tid_plain);
     }
 
     function _createMountainPath() private {
@@ -260,6 +338,23 @@ contract GameSetupSystem is System, Constants {
                                "path", path_actions);
         dObjs[0] = dirObj1;
 
+        // KPATH -> E
+        uint32 open_2_actII = createAction(ActionType.Open, "The boulder, blasted to pieces reveals a path to a new adventure.\n"
+                                                            "This is the end of ACT I, if you go East you will return to the plain.", false, false, false, 0, 0);
+
+        uint32 destroy_boulder = createAction(ActionType.Throw, "The dynamite lands at the boulder while you keep running\n"
+                                "and in just a second KBOOOM!", 
+                                true, false, false, open_2_actII, 0);
+        
+        uint32[MAX_OBJ] memory boulder_actions;
+        boulder_actions[0] = open_2_actII;
+        boulder_actions[1] = destroy_boulder;
+
+        uint32 dirObj2 = createDirObj(DirectionType.East, KPlain,
+                                DirObjectType.Boulder, MaterialType.Stone,
+                                "boulder", boulder_actions);
+
+        dObjs[1] = dirObj2;
 
         bytes32 tid_mpath = keccak256(abi.encodePacked("a high mountain pass"));
         TxtDefStore.set(tid_mpath, KMountainPath, TxtDefType.Place,
@@ -280,6 +375,7 @@ contract GameSetupSystem is System, Constants {
         _setupBarn();
         _createMountainPath();
         _setupForge();
+        _setupCellar();
     }
 
     function createDirObj(DirectionType dirType, uint32 dstId, DirObjectType dOType,

--- a/packages/contracts/src/systems/GameSetupSystem.sol
+++ b/packages/contracts/src/systems/GameSetupSystem.sol
@@ -98,19 +98,22 @@ contract GameSetupSystem is System, Constants {
 
         plain_barn[0] = open_2_barn;
 
-        SizedArray.add(dObjs,createDirObj(DirectionType.North, KBarn,
+        uint32 dirObj1 = createDirObj(DirectionType.North, KBarn,
                               DirObjectType.Path, MaterialType.Dirt,
-                              "path", plain_barn));
+                              "path", plain_barn);
+        dObjs[0] = dirObj1;
 
         uint32 open_2_path = createAction(ActionType.Open, "the door opens and a small hinge demon curses you\n"
                                 "your nose is really itchy",
                                 true, true, true, 0, 0);
 
         uint32[MAX_OBJ] memory plain_path;
-        plain_barn[0] = open_2_path;
-        SizedArray.add(dObjs,createDirObj(DirectionType.East, KMountainPath,
+        plain_path[0] = open_2_path;
+        
+        uint32 dirObj2 = createDirObj(DirectionType.East, KMountainPath,
                               DirObjectType.Path, MaterialType.Mud,
-                              "path", plain_path));
+                              "path", plain_path);
+        dObjs[1] = dirObj2;
 
         uint32 kick = createAction(ActionType.Kick, "the ball (such as it is)"
                                 "bounces feebly\n then rolls into some fresh dog eggs\n"
@@ -120,10 +123,11 @@ contract GameSetupSystem is System, Constants {
         uint32[MAX_OBJ] memory ball_actions;
         ball_actions[0] = kick;
 
-        SizedArray.add(objs,createObject(ObjectType.Football, MaterialType.Flesh,
+         uint32 obj1 = createObject(ObjectType.Football, MaterialType.Flesh,
                                 "A slightly deflated knock off uefa football,\n"
                                 "not quite spherical, it's "
-                                "kickable though", "football", ball_actions));
+                                "kickable though", "football", ball_actions);
+        objs[0] = obj1;
 
         RoomStore.setDescription(KPlain,  'a windswept plain');
         RoomStore.setRoomType(KPlain,  RoomType.Plain);
@@ -138,7 +142,63 @@ contract GameSetupSystem is System, Constants {
     }
 
     function _setupForge() private {
+        // KForge -> W
+        uint32 open_2_barn = createAction(ActionType.Open, "The broken window is still there\n"
+		" just don't cut yourself\n", true, true, true, 0, 0);
 
+        uint32[MAX_OBJ] memory forge_barn;        
+        uint32[MAX_OBJ] memory dObjs;
+        uint32[MAX_OBJ] memory objs;
+
+        forge_barn[0] = open_2_barn;
+
+        uint32 dirObj1 = createDirObj(DirectionType.West, KBarn,
+                                DirObjectType.Window, MaterialType.Wood,
+                                "window", forge_barn);
+        dObjs[0] = dirObj1;
+
+         // Petrol Object
+        uint32 burn = createAction(ActionType.Burn, "the petrol (with its unique funny smell)"
+		                    "burns fiercely with a scent that makes you feel dizzy", 
+                            true, false, true, 0, 0);
+
+        uint32[MAX_OBJ] memory petrol_actions;
+        petrol_actions[0] = burn;
+
+        uint32 obj1 = createObject(ObjectType.Petrol, MaterialType.IKEA,
+                                "a strange liquid that seems to be petrol,\n"
+                                "probably there are about 3 litres of it, "
+                                "its highly flammable", "petrol", petrol_actions);
+        objs[0] = obj1;
+
+
+        // Matches Object
+        uint32 light = createAction(ActionType.Light, "the matches (despite their small size)"
+		                    " lights enough to see a small distance\n"
+                            "you have to use them quickly"
+                            " or your fingers will get burnt", 
+                            true, false, true, 0, 0);
+
+        
+        uint32[MAX_OBJ] memory matches_actions;
+        matches_actions[0] = light;
+
+        uint32 obj2 = createObject(ObjectType.Matches, MaterialType.Wood,
+                                "a box of matches that have survived the passing of the ages,\n"
+                                "you can probably light them up, as they seem to be in a good condition\n",
+                                "matches", matches_actions);
+        objs[1] = obj2;
+
+
+        RoomStore.setDescription(KForge, 'a dusty forge');
+        RoomStore.setRoomType(KForge,  RoomType.Forge);
+
+        bytes32 tid_plain = keccak256(abi.encodePacked('a dusty forge'));
+        TxtDefStore.set(tid_plain, KForge, TxtDefType.Place, "you can see that it has not been used in ages.\n"
+                                                                "There are many blood spots accross the forge and even the anvil is broken.\n"
+                                                                "You don't know what happened here.\n");
+
+        createPlace(KForge, dObjs, objs, tid_plain);
     }
 
     function _setupBarn() private {
@@ -148,9 +208,11 @@ contract GameSetupSystem is System, Constants {
         barn_plain[0] = open_2_south;
         uint32[MAX_OBJ] memory dObjs;
         uint32[MAX_OBJ] memory objs;
-        SizedArray.add(dObjs,createDirObj(DirectionType.South, KPlain,
+
+        uint32 dirObj1 = createDirObj(DirectionType.South, KPlain,
                                 DirObjectType.Door, MaterialType.Wood,
-                                "door", barn_plain));
+                                "door", barn_plain);
+        dObjs[0] = dirObj1;
 
         // this is NOT enabled NOR OPEN
         uint32 open_2_forest = createAction(ActionType.Open, "the window, glass and frame smashed"
@@ -165,9 +227,10 @@ contract GameSetupSystem is System, Constants {
         window_actions[0] = open_2_forest;
         window_actions[1] = smash_window;
 
-        SizedArray.add(dObjs, createDirObj(DirectionType.East, KForge,
+        uint32 dirObj2 = createDirObj(DirectionType.East, KForge,
                                 DirObjectType.Window, MaterialType.Wood,
-                                "window", window_actions));
+                                "window", window_actions);
+        dObjs[1] = dirObj2;
 
         bytes32 tid_barn = keccak256(abi.encodePacked("a barn"));
         TxtDefStore.set(tid_barn, KBarn, TxtDefType.Place,
@@ -187,15 +250,15 @@ contract GameSetupSystem is System, Constants {
         uint32[MAX_OBJ] memory path_actions;
         path_actions[0] = open_2_west;
 
-        uint32[MAX_OBJ] memory dirObjs;
+        uint32[MAX_OBJ] memory dObjs;
         uint32[MAX_OBJ] memory objs;
         // this is a path we might want to say BLOCK it which would mean adding a BLOCK
         // and an OPEN which we would set to false but as can be seen above right
         // now its just open and there is no state change to describe it
-        SizedArray.add(dirObjs,createDirObj(DirectionType.West, KPlain,
+         uint32 dirObj1 = createDirObj(DirectionType.West, KPlain,
                                DirObjectType.Path, MaterialType.Stone,
-                               "path", path_actions));
-
+                               "path", path_actions);
+        dObjs[0] = dirObj1;
 
 
         bytes32 tid_mpath = keccak256(abi.encodePacked("a high mountain pass"));
@@ -208,7 +271,7 @@ contract GameSetupSystem is System, Constants {
 
         RoomStore.setDescription(KMountainPath,  "a high mountain pass");
         RoomStore.setRoomType(KMountainPath,  RoomType.Plain);
-        createPlace(KMountainPath, dirObjs, objs, tid_mpath);
+        createPlace(KMountainPath, dObjs, objs, tid_mpath);
 
     }
 
@@ -216,6 +279,7 @@ contract GameSetupSystem is System, Constants {
         _setupPlain();
         _setupBarn();
         _createMountainPath();
+        _setupForge();
     }
 
     function createDirObj(DirectionType dirType, uint32 dstId, DirObjectType dOType,

--- a/packages/contracts/src/systems/InventorySystem.sol
+++ b/packages/contracts/src/systems/InventorySystem.sol
@@ -10,15 +10,19 @@ import {ObjectType} from '../codegen/common.sol';
 import {Player, RoomStore, ObjectStore, Output} from '../codegen/index.sol';
 
 contract InventorySystem is System {
+    uint constant MAX_OBJ = 32;
 
     function inventory(address world, uint32 playerId) public returns (uint8 err) {
         uint32[32] memory objIds = Player.getObjectIds(playerId);
-        if (SizedArray.count(objIds) == 0) {
+        uint32 objCount = countNonZero(objIds);
+
+        if (objCount == 0) {
             Output.set(playerId,"Your carrier bag is empty");
             return 0;
         }
+
         string memory itemTxt = "You have a ";
-        for (uint8 i = 0; i < SizedArray.count(objIds); i++) {
+        for (uint8 i = 0; i < objCount; i++) {
             uint32 objectId = objIds[i];
                 if(i > 0) {
                     itemTxt = string.concat(itemTxt, " and a ");
@@ -36,24 +40,24 @@ contract InventorySystem is System {
         ObjectType objType = IWorld(world).mp_TokeniserSystem_getObjectType(tok);
         if (objType != ObjectType.None) {
 
-            uint32[32] memory roomObjIds = RoomStore.getObjectIds(rId);
+            uint32[MAX_OBJ] memory roomObjIds = RoomStore.getObjectIds(rId);
 
-            console.log("----->TAKE room object item count:%d", SizedArray.count(roomObjIds));
+            uint32 roomObjCount = countNonZero(roomObjIds);
+            console.log("----->TAKE room object item count:%d", roomObjCount);
 
-            for (uint8 i = 0; i < SizedArray.count(roomObjIds); i++) {
+            for (uint8 i = 0; i < roomObjCount; i++) {
                 ObjectType testType = ObjectStore.getObjectType(roomObjIds[i]);
                 if (testType == objType) {
                     Output.set(playerId,"You picked it up");
 
                     // add the item to the inventory
                     uint32[32] memory playerObjIds = Player.getObjectIds(playerId);
-                    SizedArray.add(playerObjIds, roomObjIds[i]);
+                    addElement(playerObjIds, roomObjIds[i]);
                     Player.setObjectIds(playerId, playerObjIds);
 
                     // delete from the room
-                    SizedArray.remove(roomObjIds, i);
-
-                    RoomStore.setObjectIds(rId, roomObjIds);
+                   removeElement(roomObjIds, i);
+                   RoomStore.setObjectIds(rId, roomObjIds);
 
                     itemPickedUp = true;
                     break;
@@ -74,19 +78,21 @@ contract InventorySystem is System {
         string memory tok = tokens[1];
         ObjectType objType = IWorld(world).mp_TokeniserSystem_getObjectType(tok);
         if (objType != ObjectType.None) {
-            uint32[32] memory playerObjIds = Player.getObjectIds(playerId);
-            for (uint8 i = 0; i < SizedArray.count(playerObjIds); i++) {
+            uint32[MAX_OBJ] memory playerObjIds = Player.getObjectIds(playerId);
+
+            for (uint8 i = 0; i < playerObjIds.length; i++) {
+
                 ObjectType testType = ObjectStore.getObjectType(playerObjIds[i]);
                 if (testType == objType) {
                     Output.set(playerId,"You took the item from your faded Aldi bag and placed it on the floor");
 
                     // add the item to the room
                     uint32[32] memory roomObjIds = RoomStore.getObjectIds(rId);
-                    SizedArray.add(roomObjIds, playerObjIds[i]);
+                    addElement(roomObjIds, playerObjIds[i]);
                     RoomStore.setObjectIds(rId, roomObjIds);
 
                     // delete from the inventory
-                    SizedArray.remove(playerObjIds, i);
+                    removeElement(playerObjIds, i);
                     Player.setObjectIds(playerId, playerObjIds);
 
                     return 0;
@@ -100,6 +106,36 @@ contract InventorySystem is System {
         return 0;
     }
 
+       function countNonZero(uint32[MAX_OBJ] memory arr) private pure returns (uint32) {
+        uint32 count = 0;
+        for (uint8 i = 0; i < arr.length; i++) {
+            if (arr[i] != 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    function addElement(uint32[MAX_OBJ] memory arr, uint32 element) private pure returns (bool) {
+        for (uint8 i = 0; i < arr.length; i++) {
+            if (arr[i] == 0) {
+                arr[i] = element;
+                return true;
+            }
+        }
+        return false; // Array is full
+    }
+
+    function removeElement(uint32[MAX_OBJ] memory arr, uint8 index) private pure returns (bool) {
+        if (index >= arr.length || arr[index] == 0) {
+            return false;
+        }
+        for (uint8 i = index; i < arr.length - 1; i++) {
+            arr[i] = arr[i + 1];
+        }
+        arr[arr.length - 1] = 0;
+        return true;
+    }
 
 }
 

--- a/packages/contracts/src/systems/LookSystem.sol
+++ b/packages/contracts/src/systems/LookSystem.sol
@@ -83,7 +83,15 @@ contract LookSystem is System {
 
     function _genObjDesc(uint32[32] memory objs) private view returns (string memory) {
 
-        uint32 count = SizedArray.count(objs);
+        uint32 count = 0;
+
+        // Count non-zero elements in the objs array
+        for (uint8 i = 0; i < objs.length; i++) {
+            if (objs[i] != 0) {
+                count++;
+            }
+        }
+
         if (count != 0) {// if the first item is 0 then there are no objects
             string memory objsDesc = "\nYou can also see a ";
             for (uint8 i = 0; i < count; i++) {
@@ -112,7 +120,14 @@ contract LookSystem is System {
     // there is a PATH made os mud to the DIR | there is a wood door to the
     function _genExitDesc(uint32[32] memory objs, address wrld) private view returns (string memory) {
 
-        uint32 count = SizedArray.count(objs);
+         uint32 count = 0;
+
+        // Count non-zero elements in the objs array
+        for (uint8 i = 0; i < objs.length; i++) {
+            if (objs[i] != 0) {
+                count++;
+            }
+        }
 
         if (count != 0) {// if the first item is 0 then there are no objects
             string memory exitsDesc = "\nThere is a ";

--- a/packages/contracts/src/systems/TokeniserSystem.sol
+++ b/packages/contracts/src/systems/TokeniserSystem.sol
@@ -143,6 +143,7 @@ contract TokeniserSystem is System {
         responseLookup[ActionType.Light] = [ActionType.Burn, ActionType.Light, ActionType.Damage];
         responseLookup[ActionType.Open] = [ActionType.Open];
         responseLookup[ActionType.Break] = [ActionType.Break];
+        responseLookup[ActionType.Throw] = [ActionType.Throw];
     }
 
     function setupRevVrb() private {
@@ -221,6 +222,7 @@ contract TokeniserSystem is System {
         dirObjLookup["LADDER"]      = DirObjectType.Ladder;
         dirObjLookup["PATH"]        = DirObjectType.Path;
         dirObjLookup["TRAIL"]       = DirObjectType.Trail;
+        dirObjLookup["BOULDER"]       = DirObjectType.Boulder;
 
         reverseDObjLookup[DirObjectType.Door]        = "door";
         reverseDObjLookup[DirObjectType.Window]      = "window";
@@ -228,6 +230,7 @@ contract TokeniserSystem is System {
         reverseDObjLookup[DirObjectType.Ladder]      = "ladder";
         reverseDObjLookup[DirObjectType.Path]        = "path";
         reverseDObjLookup[DirObjectType.Trail]       = "trail";
+        reverseDObjLookup[DirObjectType.Boulder]        = "boulder";
     }
 
     // TODO: we probably no longer need this
@@ -244,8 +247,10 @@ contract TokeniserSystem is System {
         objLookup["KEY"]        = ObjectType.Key;
         objLookup["KNIFE"]      = ObjectType.Knife;
         objLookup["BOTTLE"]     = ObjectType.Bottle;
-         objLookup["PETROL"]     = ObjectType.Petrol;
-          objLookup["MATCHES"]     = ObjectType.Matches;
+        objLookup["PETROL"]     = ObjectType.Petrol;
+        objLookup["MATCHES"]     = ObjectType.Matches;
+        objLookup["DYNAMITE"]     = ObjectType.Dynamite;
+        objLookup["GLUE"]     = ObjectType.Glue;
 
         reverseObjLookup[ObjectType.Football]   = "Football";
         reverseObjLookup[ObjectType.Key]        = "Key";
@@ -253,6 +258,8 @@ contract TokeniserSystem is System {
         reverseObjLookup[ObjectType.Bottle]     = "Bottle";
         reverseObjLookup[ObjectType.Petrol]     = "Petrol";
         reverseObjLookup[ObjectType.Matches]     = "Matches";
+        reverseObjLookup[ObjectType.Dynamite]     = "Dynamite";
+        reverseObjLookup[ObjectType.Glue]     = "Glue";
 
         revMat[MaterialType.Mud]    = "mud";
         revMat[MaterialType.Dirt]   = "dirt";

--- a/packages/contracts/src/systems/TokeniserSystem.sol
+++ b/packages/contracts/src/systems/TokeniserSystem.sol
@@ -244,11 +244,15 @@ contract TokeniserSystem is System {
         objLookup["KEY"]        = ObjectType.Key;
         objLookup["KNIFE"]      = ObjectType.Knife;
         objLookup["BOTTLE"]     = ObjectType.Bottle;
+         objLookup["PETROL"]     = ObjectType.Petrol;
+          objLookup["MATCHES"]     = ObjectType.Matches;
 
         reverseObjLookup[ObjectType.Football]   = "Football";
         reverseObjLookup[ObjectType.Key]        = "Key";
         reverseObjLookup[ObjectType.Knife]      = "Knife";
         reverseObjLookup[ObjectType.Bottle]     = "Bottle";
+        reverseObjLookup[ObjectType.Petrol]     = "Petrol";
+        reverseObjLookup[ObjectType.Matches]     = "Matches";
 
         revMat[MaterialType.Mud]    = "mud";
         revMat[MaterialType.Dirt]   = "dirt";


### PR DESCRIPTION
-In the **Game Setup System** I implemented the forge and cellar rooms with their objs and dirObjs. The barn and mountain path with the new  corresponding dirObjs.  Also the when creating the objects and dirObjects I'm using now a normal array.
-In the **Look System** I refactored the code where it generates the description of objs and dirObjs so that instead of using the sized array it uses the normal array. 
-In the **Inventory System** was done the same as above to check inventory, take and drop objects.
-In the **Tokeniser System** added the necessary elements to the maps
-In the **Mud Config** added the necessary variables to the tables.

What is left will be to work on the **Action System** to make it work properly. Will be doing that on Monday.